### PR TITLE
gloablise variable

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -280,6 +280,6 @@
 		@content;
 		$_o-topper-defined: map-merge($_o-topper-defined, (
 			$label: true
-		));
+		)) !global;
 	}
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -18,6 +18,6 @@ $_o-topper-themes: (
 	'centered',
 );
 
-$_o-topper-defined: ();
+$_o-topper-defined: () !default;
 
 $o-topper-is-silent: true !default;


### PR DESCRIPTION
`$_o-topper-defined` would have consistently output an empty list because the variable in the mixin wasn't being set globally (yay @notlee for the explanation). And with a `!default` flag, it will check for a pre-existing variable so as to avoid overwriting it.