### PR TITLE
Improve fallback font size.

### DIFF
--- a/scss/themes/_package.scss
+++ b/scss/themes/_package.scss
@@ -30,12 +30,8 @@
 
 	%_o-topper__tag,
 	.o-topper__headline {
-		@include oTypographySans(6, $line-height: 1em);
+		@include oTypographySans(6);
 		font-weight: 400;
-
-		@include oGridRespondTo(L) {
-			@include _oTypographyProgressiveFontFallbackSize('sans', 8);
-		}
 	}
 
 	.o-topper__headline {


### PR DESCRIPTION
The fallback font whilst Metric loads used to be huge:
![kapture 2018-05-22 at 13 52 30](https://user-images.githubusercontent.com/10405691/40363457-7a0112a4-5dc7-11e8-98e0-ae90730248a3.gif)

But now is much more in keeping:
![kapture 2018-05-22 at 13 50 07](https://user-images.githubusercontent.com/10405691/40363478-8a2a6e50-5dc7-11e8-935a-08945bad681a.gif)

Added benefit: stops using the private mixin `_oTypographyProgressiveFontFallbackSize`.

I'm not sure if there is a reason I'm unaware of for this override?
