### PR TITLE
Including themes in non silent mode

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -13,6 +13,7 @@
 @if ($o-topper-is-silent == false) {
 	@include oTopperElements;
 	@include oTopperColors;
+	@include oTopperThemes;
 
 	$o-topper-is-silent: true !global;
 }


### PR DESCRIPTION
At the moment, not all of the css is being outputted when in non silent mode, which means that the css outputted by the build service is incomplete. This PR ensures that the themes are also outputted in non silent mode.