### PR TITLE
Prevent tags wrapping too early on small screens

### DIFF
--- a/scss/themes/_branded.scss
+++ b/scss/themes/_branded.scss
@@ -22,13 +22,16 @@
 	.o-topper__tags,
 	.o-topper__standfirst {
 		box-sizing: border-box;
-		padding-right: calc(#{$_o-topper-headshot-width} + #{oTypographySpacingSize(2)});
+	}
 
+	.o-topper__standfirst {
+		padding-right: calc(#{$_o-topper-headshot-width} + #{oTypographySpacingSize(2)});
 		@include oGridRespondTo(M) {
 			padding-right: calc(#{$_o-topper-headshot-width-M} + #{oTypographySpacingSize(2)});
 		}
 	}
 
+	.o-topper__tags,
 	.o-topper__headline {
 		@include oGridRespondTo(M) {
 			padding-right: calc(#{$_o-topper-headshot-width-M} + #{oTypographySpacingSize(2)});


### PR DESCRIPTION
![screenshot 2018-12-07 at 15 29 22](https://user-images.githubusercontent.com/616321/49656342-06420200-fa35-11e8-988f-1249d9fe062a.png)

->

![screenshot 2018-12-07 at 15 30 09](https://user-images.githubusercontent.com/616321/49656355-0e9a3d00-fa35-11e8-943b-6a13d51ac030.png)


The spacing afforded to the headshot by the tags now matches the headline. 

Looking at the demos for this component, looks like this should be ok - I couldn't see any reason why the tags should make way for the headshot, given the headline sits in between them. Could do with some advice on this tho!

