### PR TITLE
Do not set font size of standfirst links.

### DIFF
--- a/src/scss/_elements.scss
+++ b/src/scss/_elements.scss
@@ -2,10 +2,6 @@
 	@include oEditorialTypographyStandfirst();
 	opacity: 0.8;
 
-	a {
-		@include oTypographySans(0, $include-font-family: false);
-	}
-
 	> p {
 		margin: 0;
 	}


### PR DESCRIPTION
Turns out o-topper is only used by the app. It was created so the
app could have toppers like ft.com but the ft.com migration to
o-topper never completed. They have since diverged.

https://github.com/Financial-Times/next-article/pull/3793#issuecomment-617207642

This commit migrates a fix from the ft.com topper to o-topper
for the apps benefit.

>Links in the stand first of topper were being set to 16px, while
>the text of the stand first itself is set to 20px. This looks
>strange when editorial tries to embed links within the text of
>the stand first and Mustafa Sogancilar has requested we change
>the font-size to match the rest of the stand first.

https://github.com/Financial-Times/next-article/pull/3793