### PR TITLE
Fix image credit text placement

### DIFF
--- a/src/scss/_elements.scss
+++ b/src/scss/_elements.scss
@@ -45,8 +45,8 @@
 	@include oTypographySans(-2);
 	color: oColorsByName('white');
 	position: absolute;
-	right: 12px;
-	bottom: 2px;
+	right: 2%;
+	bottom: 4%;
 	text-shadow: 1px 1px 1px oColorsByName('slate');
 }
 


### PR DESCRIPTION
This changes the placement of the image credit text so that it is placed on top of the image in the bottom right corner instead of sometimes being placed below the image and leading to a contrast ratio that is too low (not accessible).