### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,3 @@
-import mapContentToTopper from './src/js/map-content-to-topper';
+import mapContentToTopper from './src/js/map-content-to-topper.js';
 
 export { mapContentToTopper };

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "private": true,
   "name": "o-topper",
   "devDependencies": {
-    "eslint-config-origami-component": "^1.0.4",
-    "origami-ci-tools": "^2.0.0",
-    "stylelint-config-origami-component": "^1.0.2"
+    "eslint": "^7.8.1",
+    "eslint-config-origami-component": "^2.1.0",
+    "origami-ci-tools": "^2.0.2",
+    "stylelint-config-origami-component": "^1.0.4"
   }
 }

--- a/test/map-content-to-topper.test.js
+++ b/test/map-content-to-topper.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import { mapContentToTopper as subject } from '../main';
+import { mapContentToTopper as subject } from '../main.js';
 
 describe('Topper content map', () => {
 	const articleContentFixture = {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing