### PR TITLE
CI-340 Move topper image credit below image

### DIFF
--- a/src/scss/_elements.scss
+++ b/src/scss/_elements.scss
@@ -43,11 +43,12 @@
 
 @mixin _oTopperImageCredit {
 	@include oTypographySans(-2);
-	color: oColorsByName('white');
-	position: absolute;
-	right: 12px;
-	bottom: 2px;
-	text-shadow: 1px 1px 1px oColorsByName('slate');
+	color: oColorsByName('black-60');
+	position: relative;
+	clear: both;
+	float: right;
+	margin-top: oSpacingByName('s1');
+	margin-right: oSpacingByName('s3');
 }
 
 //IE9 support


### PR DESCRIPTION
Previously, an image credit was placed on top of the image. Depending on the image, there are times where there's not enough contrast between the background colour and text colour. We're now going to place the credit below the image to ensure that it's accessible.

**Before**
![image](https://user-images.githubusercontent.com/30316203/93465459-bd45ff80-f8e2-11ea-8286-e7c12981f430.png)

**After**
![image](https://user-images.githubusercontent.com/30316203/93465427-aacbc600-f8e2-11ea-893c-e5e9d1709efa.png)

This unblocks https://github.com/Financial-Times/o-topper/pull/59 from being released.