### PR TITLE
CI-342 Update `mapContentToTopper` function export

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,3 @@
 import mapContentToTopper from 'n-map-content-to-topper';
 
-export { mapContentToTopper };
+export default mapContentToTopper;


### PR DESCRIPTION
We export an object in `n-map-content-to-topper` and then we export that
object in another object in this component. As a result, this is what
you had to do to use the `mapContentToTopper` function:

```
const { mapContentToTopper } = require('@financial-times/o-topper');

const topper = mapContentToTopper.mapContentToTopper(article);
```

Not great. To avoid this, we're not going to export an object in this
component.