### PR TITLE
AT-3894 Remove min-height from split-text content on mobile

### DIFF
--- a/src/scss/themes/_split-text.scss
+++ b/src/scss/themes/_split-text.scss
@@ -18,7 +18,6 @@
 			flex-direction: column;
 			justify-content: center;
 			padding: 20px 10px;
-			min-height: 350px;
 		}
 
 		.o-topper__visual {


### PR DESCRIPTION
This removes any extra vertical spacing around the headline when displayed as a single column (with the visual below as opposed to on the right)

https://financialtimes.atlassian.net/browse/AT-3894