### PR TITLE
Update topper summary link styles

### DIFF
--- a/demos/src/package-special-report.mustache
+++ b/demos/src/package-special-report.mustache
@@ -16,13 +16,12 @@
 
 	<figure class="o-topper__visual">
 		<picture class="o-topper__picture">
-			<source media="(min-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/0eac32d0-1cec-4f20-a183-d9f4370309fb.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1067 1067w">
+			<source media="(min-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/ftcms:0eac32d0-1cec-4f20-a183-d9f4370309fb?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1067 1067w">
 			
-			<source media="(max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/63ebca9e-3091-4cde-a958-33ee6405c741.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=720 720w">
+			<source media="(max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/ftcms:63ebca9e-3091-4cde-a958-33ee6405c741?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=720 720w">
 			
-			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/0eac32d0-1cec-4f20-a183-d9f4370309fb.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1067">
+			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/ftcms:0eac32d0-1cec-4f20-a183-d9f4370309fb?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1067">
 		</picture>
 	</figure>
 </div>
-
 

--- a/demos/src/package-special-report.mustache
+++ b/demos/src/package-special-report.mustache
@@ -1,0 +1,28 @@
+<div class="o-topper o-topper--split-text-left o-topper--package o-topper--special-report o-topper--color-claret">
+	<div class="o-topper__content">
+		<div class="o-topper__tags">
+			<a href="https://www.ft.com/reports" class="o-topper__topic tags--large">Special Report</a>
+		</div>
+		<h1 class="o-topper__headline o-topper__headline--large" data-trackable="header">
+			<span class="article-classifier__gap">Europe’s Leading Patent Law Firms</span>
+		</h1>
+		<div class="o-topper__summary o-topper__summary--body">
+			<p>We highlight Europe’s leading patent law firms for 2020. Plus: invention still needs the human touch; pandemic reignites debate on rights protection; UK and Germany hinder Unified Patent Court launch; counterfeiting still rife beyond EU; university spinouts seek full value in commercial applications</p>
+			<p><a href="https://www.statista.com/page/europes-leading-patent-law-firms-2021-registration"><em>Apply for the 2021 ranking here</em></a></p>
+		</div>
+	</div>
+
+	<div class="o-topper__background"></div>
+
+	<figure class="o-topper__visual">
+		<picture class="o-topper__picture">
+			<source media="(min-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/0eac32d0-1cec-4f20-a183-d9f4370309fb.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1067 1067w">
+			
+			<source media="(max-width: 1440px)" srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/63ebca9e-3091-4cde-a958-33ee6405c741.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=720 720w">
+			
+			<img alt="" class="o-topper__image" src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/0eac32d0-1cec-4f20-a183-d9f4370309fb.jpg?source=next&amp;fit=scale-down&amp;quality=highest&amp;width=1067">
+		</picture>
+	</figure>
+</div>
+
+

--- a/origami.json
+++ b/origami.json
@@ -81,6 +81,12 @@
 			"description": "Theme for Packages that editorial can choose, which comes through the API."
 		},
 		{
+			"name": "Package Special Report",
+			"title": "Special Report Package Landing Page Topper",
+			"template": "/demos/src/package-special-report.mustache",
+			"description": "Used for Special Reports, such as FT Wealth"
+		},
+		{
 			"name": "News Package",
 			"title": "News Series Landing Page Topper",
 			"template": "/demos/src/news-package.mustache",

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -244,7 +244,8 @@
 	}
 
 	@if not $is-light {
-		.o-topper__standfirst {
+		.o-topper__standfirst,
+		.o-topper__summary {
 			a {
 				color: $foreground;
 				border-bottom-color: $foreground;


### PR DESCRIPTION
`o-topper` has a useful mixin that based on the topper background colour it sets a contrasting text colour. This works really well with a topper standfirst however, this does not work for a topper summary containing links. This pull request properly styles summary links.

At the suggestion of Lee, I have created a demo for special report packages. It's helpful to have because it's one of the few topper types that contains a summary.

**Demo**

![image](https://user-images.githubusercontent.com/30316203/106762567-dd762100-662d-11eb-9d2b-4d4e91a33966.png)

**FT.com**

**Before**
![image](https://user-images.githubusercontent.com/30316203/106763187-7efd7280-662e-11eb-84b4-ab51c9f2c4f7.png)

**After**
![image](https://user-images.githubusercontent.com/30316203/106762729-08f90b80-662e-11eb-9a6d-45be04652f3e.png)
