### PR TITLE
Remove excess mobile padding from full bleed image toppers

### DIFF
--- a/demos/src/full-bleed-image-center.mustache
+++ b/demos/src/full-bleed-image-center.mustache
@@ -1,4 +1,4 @@
-<div class="o-topper o-topper--full-bleed-image-left o-topper--color-slate">
+<div class="o-topper o-topper--full-bleed-image-center o-topper--color-slate">
 	<div class="o-topper__content">
 		<div class="o-topper__tags">
 			<a href="https://www.ft.com/life-arts" class="o-topper__topic">Life &amp; Arts</a>

--- a/origami.json
+++ b/origami.json
@@ -51,6 +51,12 @@
 			"description": "This is a theme that editorial can choose, which comes through the API"
 		},
 		{
+			"name": "Full Bleed Image Center",
+			"title": "Center-Aligned Full-Bleed Image Topper",
+			"template": "/demos/src/full-bleed-image-center.mustache",
+			"description": "This is a theme that editorial can choose, which comes through the API"
+		},
+		{
 			"name": "Full Bleed Offset",
 			"title": "Offset Full-Bleed Image Topper",
 			"template": "/demos/src/full-bleed-offset.mustache",

--- a/src/scss/themes/_full-bleed-image.scss
+++ b/src/scss/themes/_full-bleed-image.scss
@@ -13,6 +13,7 @@
 	}
 
 	@include oGridRespondTo($until: M) {
+		padding: 0;
 		.o-topper__content {
 			display: flex;
 			flex-direction: column;


### PR DESCRIPTION
Removes mobile padding from full bleed image toppers (center/left)
toppers. This excess padding caused the background of the topper
to be visible when a topper colour modifier like
`o-topper--color-slate` was applied. The removed padding means text
content is closer to the edges of the viewport on mobile, but this
is inline with similar toppers such as the split text toppers.

This issue is years old, affecting the app and ft.com, perhaps it
went unnoticed or perhaps editorial are only recently using the
full bleed toppers with colour modifiers. Either way, the registry
demo for this layout used a paper coloured topper on a paper
background so it was not obvious there’s a problem looking at the
demos — so they have now been updated to use a colour modifier.

fixes: https://financialtimes.atlassian.net/browse/AT-4491

before/after small viewport

![Screenshot 2021-02-09 at 11 18 39](https://user-images.githubusercontent.com/10405691/107356457-bc4b7f80-6ac8-11eb-8f21-b2c61bc2ed6b.png)
![Screenshot 2021-02-09 at 11 18 40](https://user-images.githubusercontent.com/10405691/107356422-b5247180-6ac8-11eb-9485-8d5a32437639.png)

before/after large viewport (unchanged)

![Screenshot 2021-02-09 at 11 18 28](https://user-images.githubusercontent.com/10405691/107356500-cc635f00-6ac8-11eb-9480-5ae0cfd9ddeb.png)
![Screenshot 2021-02-09 at 11 18 33](https://user-images.githubusercontent.com/10405691/107356676-00d71b00-6ac9-11eb-92b7-6d77ddb6ef2a.png)
