### PR TITLE
AT-4491 Remove gaps in full-bleed topper on mobile

### DIFF
--- a/src/scss/themes/_full-bleed-image.scss
+++ b/src/scss/themes/_full-bleed-image.scss
@@ -20,10 +20,6 @@
 			padding: 20px;
 			min-height: 350px;
 		}
-
-		.o-topper__visual {
-			min-height: 350px;
-		}
 	}
 
 	@include oGridRespondTo(M) {


### PR DESCRIPTION
Remove min-height from topper content and visual to remove potential extra vertical space.  The gap below the visual was pointed out as an error, and I made a similar fix to the content in https://github.com/Financial-Times/o-topper/pull/80, but I'm not sure about it here:

Before:

![Selection_006](https://user-images.githubusercontent.com/54738013/107357284-ca4dd000-6ac9-11eb-8db7-6d3bf7ec3640.png)

After:

![Selection_007](https://user-images.githubusercontent.com/54738013/107357300-cd48c080-6ac9-11eb-9ffe-1490820ddc8d.png)