### PR TITLE
CI-554, CI-556: Update topper summary links

### DIFF
--- a/demos/src/live-blog-package.mustache
+++ b/demos/src/live-blog-package.mustache
@@ -1,0 +1,45 @@
+<div class="o-topper o-topper--full-bleed-offset o-topper--color-paper">
+    <div class="o-topper__content">
+        <div class="o-topper__tags"></div>
+        <h1 class="o-topper__headline o-topper__headline--large"><span class="article-classifier__gap">Coronavirus
+                latest: UK lowers Covid alert level from highest category</span></h1>
+        <div class="o-topper__summary">
+            <div class="o-topper__summary--body" data-testid="summary">
+                <p>Today’s main headlines:</p>
+                <ul>
+                    <li>
+                        <a href="#">Pfizer to test use of third dose of vaccine in fight against Covid variants</a>
+                    </li>
+                    <li>
+                        <a href="#">New US jobless claims fall to lowest level in three months</a>
+                    </li>
+                    <li>
+                        <a href="#">WHO issues alert over ‘long Covid’ impact</a>
+                    </li>
+                    <li>
+                        <a href="#">Moderna expects $18.4bn in Covid vaccine sales in 2021</a>
+                    </li>
+                    <li>
+                        <a href="#">Some UK commuters may never return, says Network Rail chairman</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="o-topper__background"></div>
+    <figure class="o-topper__visual">
+        <picture class="o-topper__picture">
+            <source media="(max-width: 1220px)"
+                srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/8f105cfc-306a-4d63-b8ba-f25e64ffeef6.jpg?source=next&amp;amp;fit=scale-down&amp;amp;quality=highest&amp;amp;width=1220 1220w"
+                data-testid="responsive-source">
+            <source media="(max-width: 490px)"
+                srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/ceb8f94e-f136-415a-b813-59edf7304031.jpg?source=next&amp;amp;fit=scale-down&amp;amp;quality=highest&amp;amp;width=490 490w"
+                data-testid="responsive-source">
+            <source media="(min-width: 1220px)"
+                srcset="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/b237a4ec-91b3-4082-984a-adf651c27465.jpg?source=next&amp;amp;fit=scale-down&amp;amp;quality=highest&amp;amp;width=1440 1440w"
+                data-testid="responsive-source"><img alt="" class="o-topper__image"
+                src="https://www.ft.com/__origami/service/image/v2/images/raw/https://d1e00ek4ebabms.cloudfront.net/production/8f105cfc-306a-4d63-b8ba-f25e64ffeef6.jpg?source=next&amp;amp;fit=scale-down&amp;amp;quality=highest&amp;amp;width=1440">
+        </picture>
+        <figcaption class="o-topper__image-credit">© REUTERS</figcaption>
+    </figure>
+</div>

--- a/origami.json
+++ b/origami.json
@@ -123,6 +123,13 @@
 			"template": "/demos/src/podcast.mustache",
 			"description": "This is used for podcast articles",
 			"hidden": true
+		},
+		{
+			"name": "Live Blog Package",
+			"title": "Live Blog Package",
+			"template": "/demos/src/live-blog-package.mustache",
+			"description": "Topper used in live blog packages",
+			"hidden": true
 		}
 	]
 }

--- a/src/scss/_elements.scss
+++ b/src/scss/_elements.scss
@@ -36,7 +36,6 @@
 			@include oTypographySans(1);
 			margin-top: oSpacingByName('s2');
 			margin-bottom: 0;
-			font-weight: 600;
 		}
 	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -244,13 +244,20 @@
 	}
 
 	@if not $is-light {
+		$hover-color: darken($foreground, 20%);
+
 		.o-topper__standfirst,
 		.o-topper__summary {
-			a,
-			a:hover {
-				color: currentColor;
-				border-bottom-color: currentColor;
-				text-decoration-color: currentColor;
+			a {
+				color: $foreground;
+				border-bottom-color: $foreground;
+				text-decoration-color: $foreground;
+
+				&:hover {
+					color: $hover-color;
+					border-bottom-color: $hover-color;
+					text-decoration-color: $hover-color;
+				}
 			}
 		}
 	}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -246,14 +246,11 @@
 	@if not $is-light {
 		.o-topper__standfirst,
 		.o-topper__summary {
-			a {
-				color: $foreground;
-				border-bottom-color: $foreground;
-
-				&:hover {
-					color: $hover-color;
-					border-bottom-color: $hover-color;
-				}
+			a,
+			a:hover {
+				color: currentColor;
+				border-bottom-color: currentColor;
+				text-decoration-color: currentColor;
 			}
 		}
 	}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -229,12 +229,8 @@
 @mixin _oTopperColor($color-name) {
 	$background: oColorsByName($color-name);
 	$foreground: oColorsGetTextColor($background, $opacity: 100);
-	$is-light: $foreground == 'white';
-	$hover-color: lighten($foreground, 40%);
-
-	@if $is-light {
-		$hover-color: darken($foreground, 20%);
-	}
+	$link-text-color: oColorsByUsecase('link', 'text');
+	$link-contrasts-with-background: oColorsGetContrastRatio($background, $link-text-color) > 4.5;
 
 	// include oTopperColor on a parent then extend this placeholder on a
 	// descendent to lend that descendent the color you specified in the mixin
@@ -243,7 +239,7 @@
 		background-color: $background;
 	}
 
-	@if not $is-light {
+	@if not $link-contrasts-with-background {
 		$hover-color: darken($foreground, 20%);
 
 		.o-topper__standfirst,


### PR DESCRIPTION
- Use default list item styles and not bold
- Fix underline colors in overriden links
- Use contrast to decide if we should use our default links, so that we dont overwrite them unnecessarily.

## Themes that are changed

| Before | After |
| - | - |
| Paper  ![](https://user-images.githubusercontent.com/2445413/109193498-54678b00-7790-11eb-8a3e-73572e600c92.png) | ![](https://user-images.githubusercontent.com/2445413/109193464-49145f80-7790-11eb-83c4-28d43eba8283.png) |
| White ![](https://user-images.githubusercontent.com/2445413/109194009-e53e6680-7790-11eb-93d6-ce367d906939.png) | ![](https://user-images.githubusercontent.com/2445413/109193986-df488580-7790-11eb-9616-15fa933a1989.png) |

All other themes are the same.


