### PR TITLE
Include default link style for toppers with colour

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -239,12 +239,16 @@
 		background-color: $background;
 	}
 
-	@if not $link-contrasts-with-background {
-		$hover-color: darken($foreground, 20%);
 
-		.o-topper__standfirst,
-		.o-topper__summary {
+	.o-topper__standfirst,
+	.o-topper__summary {
+		@if $link-contrasts-with-background {
 			a {
+				@include oTypographyLink();
+			}
+		} @else {
+			a {
+				$hover-color: darken($foreground, 20%);
 				color: $foreground;
 				border-bottom-color: $foreground;
 				text-decoration-color: $foreground;


### PR DESCRIPTION
ft.com and presumably the app style all anchor tags using `o-typography`,
so o-topper links would actually look ok when deployed in these projects.
We should use the cascade like this to avoid duplicate CSS but Origami
components are usually totally self contained, so this PR uses
`oTypographyLink` to apply the default link style in o-topper.

An alternative approach could have been to document that `a` tags must
be styled using `o-typography`, and update demo css to do tham so the
demos look as expected.