### PR TITLE
Remove support for the `velvet` background variant of o-topper, which was only ever used in the Apps and which editorial want completely removed

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,28 @@
 # Migration guide
 
+## Migrating from v4 to v5
+
+The velvet topper (previously used to indicate life and arts) has been removed.
+
+- Confirm the `.o-topper--color-velvet` class is not used, consult Origami and the design team to remove its use.
+- If your project uses the the `oTopper` Sass mixin with an options argument and `colors` key, remove `velvet` as a value.
+
+```diff
+@include oTopper($opts: (
+	'themes': (
+        //...
+	),
+	'elements': (
+        //...
+	),
+	'colors': (
+        //...
+		'sky',
+-		'velvet'
+	)
+));
+```
+
 ## Migrating from v3 to v4
 
 Support for Bower and version 2 of the Origami Build Service have been removed.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,8 +4,8 @@
 
 The velvet topper (previously used to indicate life and arts) has been removed.
 
-- Confirm the `.o-topper--color-velvet` class is not used, consult Origami and the design team to remove its use.
-- If your project uses the the `oTopper` Sass mixin with an options argument and `colors` key, remove `velvet` as a value.
+- Confirm the `.o-topper--color-velvet` class is not used - [it appears the velvet topper style is no longer used by projects](https://github.com/Financial-Times/o-topper/pull/94) - consult Origami and the design team to remove its use if it is.
+- If your project uses the `oTopper` Sass mixin with an options argument and `colors` key, remove `velvet` as a value.
 
 ```diff
 @include oTopper($opts: (

--- a/readme.md
+++ b/readme.md
@@ -160,7 +160,8 @@ const topper = mapContentToTopper(ftArticle, flags);
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 4 | N/A  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+✨ active | 5 | N/A  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+⚠ maintained | 4 | 4.0  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 ⚠ maintained | 3 | 3.1  | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 ╳ deprecated | 2 | 2.7  | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
 ╳ deprecated | 1 | 1.2  | - |

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,6 @@ These colors affect the background of the `.o-topper__background` and `.o-topper
 .o-topper--color-slate
 .o-topper--color-crimson
 .o-topper--color-sky
-.o-topper--color-velvet
 ```
 
 ## Sass
@@ -127,7 +126,7 @@ To include o-topper styles granularly specify which elements, themes, and colour
 		'topic',
 		'read-next',
 		'image',
-		'image-credit'
+		'image-credit',
 	),
 	'colors': (
 		'white', // .o-topper--color-white
@@ -139,7 +138,6 @@ To include o-topper styles granularly specify which elements, themes, and colour
 		'wheat',
 		'crimson',
 		'sky',
-		'velvet'
 	)
 ));
 ```

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -15,7 +15,6 @@ $_o-topper-colors: (
 	'wheat',
 	'crimson',
 	'sky',
-	'velvet'
 );
 
 /// When adding a new theme update the README


### PR DESCRIPTION
The "velvet" topper was historically used to indicate "weekend" (or "Life & Arts") articles in the Apps. I believe it was never actually exposed as a colour in methode/Spark as a background, but there was apps-specific logic to add the header according to various rules.

Editorial now want the velvet toppers removed entirely, which the app has now done and will release shortly; as a result I *think* we can remove support from o-topper as well.

The only question is whether this functionality was used elsewhere! It wasn't used on ft.com; I think strictly speaking this merits a major version as it's removal of a style, but the migration guide will be "change velvet to a different colour". Should I add migration guides etc as part of this PR? What's the usual approach to style removals?