### PR TITLE
Improve the focus outline contrast on topper links to meet contrast requirement

### DIFF
--- a/src/scss/_elements.scss
+++ b/src/scss/_elements.scss
@@ -71,6 +71,11 @@
 			&:hover {
 				color: unset;
 			}
+			&:focus,
+			&:hover,
+			&:visited {
+				outline-color: currentColor;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This was surfaced during the recent accessibility audit, [here is the Jira ticket for the work](https://financialtimes.atlassian.net/browse/CON-1096)

I've asked in [#design-system-guild channel](https://financialtimes.slack.com/archives/C01481FKWA2/p1630580173017300) for their review on the design change

Before:
![image](https://user-images.githubusercontent.com/1569131/131830667-1281b3ca-dfe9-42ea-b75d-b61ab3596bba.png)

After:
![image](https://user-images.githubusercontent.com/1569131/131830747-1f5da366-fb07-47e1-b4e5-1d15a4e8c90f.png)

Before:
![image](https://user-images.githubusercontent.com/1569131/131830889-f89873a1-30fb-444c-a166-18a27cadd912.png)


After:
![image](https://user-images.githubusercontent.com/1569131/131830827-eb1d0c99-5879-43c0-ab30-a7312b17e109.png)

