### PR TITLE
 Improve the focus outline contrast on topper links to meet contrast requirement

### DIFF
--- a/src/scss/_elements.scss
+++ b/src/scss/_elements.scss
@@ -71,6 +71,11 @@
 			&:hover {
 				color: unset;
 			}
+			&:focus,
+			&:hover,
+			&:visited {
+				outline-color: currentColor;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is a backport of #96 for v3 of o-topper because Customer Products are stuck on that version for the time being